### PR TITLE
Fix #4 : make all toggle buttons the same size

### DIFF
--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -19,7 +19,7 @@
 
     <org.honorato.multistatetogglebutton.MultiStateToggleButton
         android:id="@+id/mstb_multi2_id"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="10dip"
         mstb:values="@array/dogs_array" />

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
 
     <string-array name="dogs_array">
         <item>Pug</item>
-        <item>Collie</item>
+        <item>Cavalier King Charles Spaniel</item>
         <item>Doge</item>
         <item>Pup</item>
         <item>Golden</item>

--- a/multistatetogglebutton/res/layout/view_center_toggle_button.xml
+++ b/multistatetogglebutton/res/layout/view_center_toggle_button.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v7.widget.AppCompatButton xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/mstb_button_view"
-    android:layout_width="wrap_content"
+    android:layout_width="0dp"
     android:layout_height="fill_parent"
     android:layout_weight="1"
     style="@style/ToggleStyle"

--- a/multistatetogglebutton/res/layout/view_left_toggle_button.xml
+++ b/multistatetogglebutton/res/layout/view_left_toggle_button.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v7.widget.AppCompatButton xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/mstb_button_view"
-    android:layout_width="wrap_content"
+    android:layout_width="0dp"
     android:layout_height="fill_parent"
     android:layout_weight="1"
     android:text="@string/left" />

--- a/multistatetogglebutton/res/layout/view_right_toggle_button.xml
+++ b/multistatetogglebutton/res/layout/view_right_toggle_button.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v7.widget.AppCompatButton xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/mstb_button_view"
-    android:layout_width="wrap_content"
+    android:layout_width="0dp"
     android:layout_height="fill_parent"
     android:layout_weight="1"
     android:text="@string/right" />


### PR DESCRIPTION
Someone else found a solution to this bug already but since it was not pushed upstream, here it is :)

There is a little gotcha, if the size is not directly defined (such as `layout_width="wrap_content`) the button will indeed wrap to the size of their content (see the third line of buttons on both screenshot).
Otherwise (`layout_width="wrap_content` or `layout_width="180dp` and so on), the buttons will have the same size (see second line)

Before:
<img src="https://cloud.githubusercontent.com/assets/8037169/13293622/a9194632-db20-11e5-82f1-964eb3466b5e.png" width="350">
After:
<img src="https://cloud.githubusercontent.com/assets/8037169/13293624/aa28b5d0-db20-11e5-8727-d5665d133514.png" width="350">