### PR TITLE
Fix compile without local.properies

### DIFF
--- a/multistatetogglebutton/build.gradle
+++ b/multistatetogglebutton/build.gradle
@@ -35,7 +35,10 @@ android {
 }
 
 Properties properties = new Properties()
-properties.load(project.rootProject.file('local.properties').newDataInputStream())
+File file = project.rootProject.file('local.properties')
+if (file.isFile()) {
+    properties.load(project.rootProject.file('local.properties').newDataInputStream())
+}
 
 bintray {
     user = properties.getProperty("bintray.user")


### PR DESCRIPTION
When you use `ANDROID_HOME` instead of `local.properties`, possible to build project without error on missing `local.properties` file.