### PR TITLE
removed default bold style from normal text

### DIFF
--- a/multistatetogglebutton/res/values/styles.xml
+++ b/multistatetogglebutton/res/values/styles.xml
@@ -24,7 +24,6 @@
 
     <style name="PrimaryNormalText" parent="@android:style/Widget.TextView">
         <item name="android:textColor">?attr/colorPrimary</item>
-        <item name="android:textStyle">bold</item>
     </style>
 
     <style name="ToggleStyle">


### PR DESCRIPTION
The default text style currently makes all normal textviews bold. This makes it difficult for situations where the user wants a multistate toggle button with normal texts. The current change will give users the freedom to change textview styles